### PR TITLE
Fixed getReleaseFeedUrl to point to raw JSON file

### DIFF
--- a/twigpcre/TwigPcrePlugin.php
+++ b/twigpcre/TwigPcrePlugin.php
@@ -17,12 +17,12 @@ class TwigPcrePlugin extends BasePlugin
 
     public function getVersion()
     {
-        return '0.3';
+        return '0.3.1';
     }
-	
-	public function getSchemaVersion() {
-		return '0.1';
-	}
+    
+    public function getSchemaVersion() {
+    	return '0.1';
+    }
 
     public function getDeveloper()
     {
@@ -38,11 +38,11 @@ class TwigPcrePlugin extends BasePlugin
     {
         return 'https://github.com/victor-in/Craft-TwigPCRE';
     }
-	
-	public function getReleaseFeedUrl()
-	{
-		return 'https://github.com/victor-in/Craft-TwigPCRE/blob/master/changelog.json';
-	}
+    
+    public function getReleaseFeedUrl()
+    {
+        return 'https://raw.githubusercontent.com/victor-in/Craft-TwigPCRE/master/changelog.json';
+    }
 
     public function addTwigExtension()
     {


### PR DESCRIPTION
Seeing errors coming up in craft.log — saw that it was barking about the release feed not being actual JSON. This just updates it to point to the actual raw JSON file instead of the Github page.

Also cleaned up the indentation in the TwigPcrePlugin.php file.
